### PR TITLE
Use process.execPath instead of process.argv0 to find node location

### DIFF
--- a/modules/setup.js
+++ b/modules/setup.js
@@ -133,7 +133,7 @@
     if (await !isFile(indexPath)) {
       throw new Error(`No such file: ${indexPath}.`);
     }
-    const node = process.argv0;
+    const node = process.execPath;
     const cmd = `${node} ${indexPath}`;
     const content = IS_WIN && `@echo off\n${cmd}\n` ||
                     `#!/usr/bin/env bash\n${cmd}\n`;


### PR DESCRIPTION
The problem of using argv0 is that it depends on the current working
directory while installing the native application which might be
different from the working directory while running. Typically, using
argv0 will break if the node binary is given with a relative
path (e.g., ./node_modules/.bin/node). Instead process.execPath is an
absolute filename.