### PR TITLE
Potential fix for code scanning alert no. 17: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -2,6 +2,8 @@
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
 name: build
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/asamuzaK/webExtNativeMsg/security/code-scanning/17](https://github.com/asamuzaK/webExtNativeMsg/security/code-scanning/17)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will apply to all jobs in the workflow unless overridden by job-specific `permissions`. Since the workflow only performs read operations (e.g., checking out the repository and installing dependencies), we will set `contents: read` as the minimal required permission. This ensures the workflow has the least privileges necessary to function correctly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
